### PR TITLE
Remove USE_QUAY_ONLY from image_build_push.yaml

### DIFF
--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -46,7 +46,6 @@ jobs:
       - select_build
     uses: uc-cdis/.github/.github/workflows/image_build_push_native.yaml@master
     with:
-      USE_QUAY_ONLY: true
       DOCKERFILE_LOCATION: ${{ needs.select_build.outputs.DOCKERFILE_LOCATION }}
       OVERRIDE_TAG_NAME: ${{ needs.compute_tag.outputs.OVERRIDE_TAG_NAME }}
     secrets:


### PR DESCRIPTION
Removed USE_QUAY_ONLY parameter from image build workflow.

<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one:

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
